### PR TITLE
Rails7: Use `ActiveRecord.default_timezone` to support Rails 7

### DIFF
--- a/lib/validates_timeliness/railtie.rb
+++ b/lib/validates_timeliness/railtie.rb
@@ -2,7 +2,7 @@ module ValidatesTimeliness
   class Railtie < Rails::Railtie
     initializer "validates_timeliness.initialize_active_record", :after => 'active_record.initialize_timezone' do
       ActiveSupport.on_load(:active_record) do
-        ValidatesTimeliness.default_timezone = ActiveRecord::Base.default_timezone
+        ValidatesTimeliness.default_timezone = ActiveRecord.default_timezone
         ValidatesTimeliness.extend_orms << :active_record
         ValidatesTimeliness.load_orms
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,7 +67,7 @@ end
 
 I18n.enforce_available_locales = false
 
-ActiveRecord::Base.default_timezone = :utc
+ActiveRecord.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.establish_connection({:adapter => 'sqlite3', :database => ':memory:'})
 ActiveRecord::Migration.verbose = false


### PR DESCRIPTION
### Task Link(s):
[AsanaTasks](https://app.asana.com/1/1110661684743291/project/1206174328591246/task/1210611065683139?focus=true)

### Purpose:
To add support for Rails 7.

### Changes:
* [Replace ActiveRecord::Base.default_timezone with ActiveRecord.default_timezone](https://github.com/WorkBright/validates_timeliness/commit/2a78ae3a819172cfc350c8ee4f5d7ab159864556)

### Demo Video or Screenshot(s):
N/A

### Local setup/testing:
Currently, there's nothing we can test within the gem itself, as its test suite is broken. If you look at the `Gemfile`, you'll see it’s configured for Rails versions >= 3.2.6 and < 3.3.0 — which means the test suite isn’t compatible with Rails 7.

Once this PR is merged, we can verify that the changes are working correctly by linking the Rails app (`Gemfile_next`) to this fork and confirming that the `undefined method 'default_timezone'` error no longer appears in the Rails app. 

![image](https://github.com/user-attachments/assets/23c02083-2168-4dff-a66e-ecea53b71e16)


### Notes:
It's kind of amazing that this gem has survived in our codebase, considering it's no longer maintained. The last commit was over 10 years ago, and it was last tested with Rails 3.2.6

So, the main goal of forking and patching it now is simply to get rid of the `undefined method 'default_timezone'` error, so we can run the Rails App's test suite on Rails 7.2

Once that's working, we can assess the effort required to replace this outdated gem with the original `validates_timeliness` gem (https://github.com/adzap/validates_timeliness), which is actively maintained and already supports Rails 7 and 8.

